### PR TITLE
Update BUILD-Readme.txt

### DIFF
--- a/BUILD-Readme.txt
+++ b/BUILD-Readme.txt
@@ -61,7 +61,7 @@ Linux x86_64:
 
 git clone https://github.com/dzimbeck/BitBay.git
 cd BitBay
-chmod +x linuxBitBay64.sh
+chmod +x linux64BitBay.sh
 ./linux64BitBay.sh --build
 
 Options:


### PR DESCRIPTION
Under Linux x86_64, the third command was incorrect as it was calling chmod +x linuxBitBay64.sh and there is no such file, I have updated it to call chmod +x linux64BitBay.sh